### PR TITLE
Span context interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-target/
+*.swp
 Cargo.lock
+
+target/

--- a/opentracing-api/src/context.rs
+++ b/opentracing-api/src/context.rs
@@ -1,0 +1,46 @@
+/// SpanContext represents Span state that must propagate to
+/// descendant Spans and across process boundaries.
+///
+/// SpanContext is logically divided into two pieces: (1) the user-level "Baggage" that
+/// propagates across Span boundaries and (2) any Tracer-implementation-specific fields
+/// that are needed to identify or otherwise contextualize the associated Span instance
+/// (e.g., a `(trace_id, span_id, sampled)` tuple).
+pub trait SpanContext<'a> {
+    /// Associated type defining how to iterate over baggage items.
+    type Iter: Iterator<Item = (&'a String, &'a String)>;
+
+    /// Iterate over baggage items.
+    ///
+    /// Baggage items are key/value pairs that are propagated from
+    /// the associated `Span` throught the trace.
+    fn baggage_items(&'a self) -> Self::Iter;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::collections::hash_map::Iter as HashMapIter;
+    use super::SpanContext;
+
+    struct TestContext {
+        items: HashMap<String, String>,
+    }
+    impl<'a> SpanContext<'a> for TestContext {
+        type Iter = HashMapIter<'a, String, String>;
+        
+        fn baggage_items(&'a self) -> Self::Iter {
+            self.items.iter()
+        }
+    }
+
+    #[test]
+    fn get_items() {
+        let mut items = HashMap::new();
+        items.insert("key".into(), "value".into());
+        let context = TestContext {
+            items: items
+        };
+        let items: Vec<(&String, &String)> = context.baggage_items().collect();
+        assert_eq!(items, [(&"key".into(), &"value".into())])
+    }
+}

--- a/opentracing-api/src/lib.rs
+++ b/opentracing-api/src/lib.rs
@@ -1,7 +1,9 @@
 #![doc(html_root_url = "https://docs.rs/opentracing-api/0.1.0")]
 
+mod context;
 mod tag;
 mod field;
 
+pub use context::SpanContext;
 pub use tag::{Tags, ParseTagsError};
 pub use field::{Fields, ParseFieldsError};


### PR DESCRIPTION
@daschl as promised, the `SpanContext` interface :smile: 
As mentioned I also added the `opentracing-util` crate.

So far it only includes the code to wrap a `SpanContext` into boxes.
There is a problem though: if the `BoxedSpanContext::baggage_items` is called the compiler complaints that the `BoxedSpanContext` instance may not leave long enough.
The error is visible even if I wrap the entire call into a nested block (so that the `BoxedSpanContext` instance would be guaranteed to have a longer lifetime).

I am sure I have failed to properly declare my lifetimes and so now the compiler does not realise the borrow is dropped when the result of `BoxedSpanContext::baggage_items` is dropped but I can't see where I went wrong.

It would be nice to have another pair of eyes on this.
The error from rust (rustc 1.24.0 (4d90ac38c 2018-02-12)):
```
error[E0597]: `context` does not live long enough
   --> opentracing-util/src/runtime.rs:155:9
    |
155 |         context.baggage_items();
    |         ^^^^^^^ borrowed value does not live long enough
156 |     }
    |     - `context` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created

error: aborting due to previous error
```