### PR TITLE
Implement Mock and Noop for SpanContext.

### DIFF
--- a/opentracing-api/src/context.rs
+++ b/opentracing-api/src/context.rs
@@ -38,7 +38,7 @@ mod tests {
     fn get_items() {
         let mut items = HashMap::new();
         items.insert("key".into(), "value".into());
-        let context = TestContext { items: items };
+        let context = TestContext { items };
         let items: Vec<(&String, &String)> = context.baggage_items().collect();
         assert_eq!(items, [(&"key".into(), &"value".into())])
     }

--- a/opentracing-mock/Cargo.toml
+++ b/opentracing-mock/Cargo.toml
@@ -11,3 +11,6 @@ keywords = ["opentracing", "tracing"]
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+[dependencies]
+opentracing-api = { path = "../opentracing-api" }

--- a/opentracing-mock/src/lib.rs
+++ b/opentracing-mock/src/lib.rs
@@ -1,1 +1,51 @@
+//! This crate provides a mocking implementation of the tracing
+//! API, especially useful for testing.
 #![doc(html_root_url = "https://docs.rs/opentracing-mock/0.1.0")]
+
+extern crate opentracing_api;
+
+use opentracing_api::SpanContext;
+use std::collections::HashMap;
+use std::collections::hash_map::Iter as HashMapIter;
+
+pub struct MockSpanContext {
+    baggage: HashMap<String, String>,
+}
+
+impl MockSpanContext {
+    /// Create a new `MockSpanContext` with the given baggage.
+    pub fn new(baggage: HashMap<String, String>) -> Self {
+        MockSpanContext { baggage }
+    }
+}
+
+impl<'a> SpanContext<'a> for MockSpanContext {
+    type Iter = HashMapIter<'a, String, String>;
+
+    fn baggage_items(&'a self) -> Self::Iter {
+        self.baggage.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::MockSpanContext;
+    use opentracing_api::SpanContext;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_map_baggage() {
+        let mut items = HashMap::new();
+        items.insert("key".into(), "value".into());
+
+        let ctx = MockSpanContext::new(items);
+        let mut iter = ctx.baggage_items();
+        assert_eq!(
+            Some((&String::from("key"), &String::from("value"))),
+            iter.next()
+        );
+        assert_eq!(None, iter.next());
+    }
+
+}

--- a/opentracing-noop/Cargo.toml
+++ b/opentracing-noop/Cargo.toml
@@ -11,3 +11,6 @@ keywords = ["opentracing", "tracing"]
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+[dependencies]
+opentracing-api = { path = "../opentracing-api" }

--- a/opentracing-noop/src/lib.rs
+++ b/opentracing-noop/src/lib.rs
@@ -1,1 +1,40 @@
+//! This crate provides a simple and cheap "noop" implementation of the
+//! tracing API and all of its sub-components.
 #![doc(html_root_url = "https://docs.rs/opentracing-noop/0.1.0")]
+
+extern crate opentracing_api;
+
+use opentracing_api::SpanContext;
+use std::iter::{empty, Empty};
+
+/// The `NoopSpanContext` just returns an empty iterator on
+/// baggage items and all of its associated content.
+pub struct NoopSpanContext {}
+
+impl Default for NoopSpanContext {
+    fn default() -> Self {
+        NoopSpanContext {}
+    }
+}
+
+impl<'a> SpanContext<'a> for NoopSpanContext {
+    type Iter = Empty<(&'a String, &'a String)>;
+
+    fn baggage_items(&'a self) -> Self::Iter {
+        empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::NoopSpanContext;
+    use opentracing_api::SpanContext;
+
+    #[test]
+    fn test_empty_baggage() {
+        let ctx = NoopSpanContext::default();
+        assert_eq!(None, ctx.baggage_items().next());
+    }
+
+}


### PR DESCRIPTION
Building on #10, this PR adds the actual implementations
for the SpanContext for Noop and Mock libraries.

@stefano-pogliani building on your change